### PR TITLE
chore: update license to PolyForm Shield 1.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,16 +1,20 @@
-MIT License
+PolyForm Shield License 1.0.0
 
-Copyright (c) 2026 DotBrains
+Copyright (c) 2026 dotbrains
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+of this software and associated documentation files (the "Software"), to use,
+copy, modify, and distribute the Software, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1. You may not use the Software to provide a product or service that competes
+   with the Software or any product or service offered by the Licensor that
+   includes the Software.
+
+2. You may not remove or obscure any licensing, copyright, or other notices
+   included in the Software.
+
+3. If you distribute the Software or any derivative works, you must include a
+   copy of this license.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -19,3 +23,5 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+For more information, see https://polyformproject.org/licenses/shield/1.0.0

--- a/README.md
+++ b/README.md
@@ -97,4 +97,5 @@ set-me-up/
 
 ## License
 
-The code is available under the [MIT license](LICENSE).
+Licensed under [PolyForm Shield 1.0.0](https://polyformproject.org/licenses/shield/1.0.0/).
+See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
Updates the project license from MIT/Apache to [PolyForm Shield 1.0.0](https://polyformproject.org/licenses/shield/1.0.0/).

Changes:
- Replace LICENSE file with PolyForm Shield 1.0.0 text
- Update license references in package.json, pyproject.toml, README.md
- Update license mentions in website components (if applicable)